### PR TITLE
Term query case

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -147,7 +147,7 @@ var ES = {};
       var out = {};
       out[filter.type] = {};
       if (filter.type === 'term') {
-        out.term[filter.field] = filter.term.toLowerCase();
+        out.term[filter.field] = filter.term;
       } else if (filter.type === 'geo_distance') {
         out.geo_distance[filter.field] = filter.point;
         out.geo_distance.distance = filter.distance;


### PR DESCRIPTION
remove .toLowerCase() filter.term since terms are case-sensitive and the user may not want to change the case.  For example, I am using not_analyzed fields as filters so they do not get lowercased by Elasticsearch.  If the term gets lowercased in the filter query, it doesn't match.
