### PR TITLE
Range and type filters

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -147,7 +147,7 @@ var ES = {};
       var out = {};
       out[filter.type] = {};
       if (filter.type === 'term') {
-        out.term[filter.field] = filter.term.toLowerCase();
+        out.term[filter.field] = filter.term;
       } else if (filter.type === 'geo_distance') {
         out.geo_distance[filter.field] = filter.point;
         out.geo_distance.distance = filter.distance;

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -152,6 +152,21 @@ var ES = {};
         out.geo_distance[filter.field] = filter.point;
         out.geo_distance.distance = filter.distance;
         out.geo_distance.unit = filter.unit;
+      } else if (filter.type === 'range') {
+        // range filter: http://www.elasticsearch.org/guide/reference/query-dsl/range-filter/
+        out.range[filter.field] = { 
+          from : filter.from, 
+          to : filter.to 
+        };
+        if (_.has(filter, 'include_lower')) {
+          out.range[filter.field].include_lower = filter.include_lower;
+        }
+        if (_.has(filter, 'include_upper')) {
+          out.range[filter.field].include_upper = filter.include_upper;
+        }
+      } else if (filter.type == 'type') {
+        // type filter: http://www.elasticsearch.org/guide/reference/query-dsl/type-filter/
+        out.type = { value : filter.value };
       }
       return out;
     },

--- a/test/tests.js
+++ b/test/tests.js
@@ -51,7 +51,7 @@ test("queryNormalize", function() {
         and: [
           {
             term: {
-              xyz: 'xxx'
+              xyz: 'XXX'
             }
           }
         ]

--- a/test/tests.js
+++ b/test/tests.js
@@ -43,10 +43,7 @@ test("queryNormalize", function() {
   ]
   var out = backend._normalizeQuery(in_);
   var exp = {
-    constant_score: {
-      query: {
-        match_all: {}
-      },
+    filtered: {
       filter: {
         and: [
           {
@@ -75,10 +72,7 @@ test("queryNormalize", function() {
   ];
   var out = backend._normalizeQuery(in_);
   var exp = {
-    constant_score: {
-      query: {
-        match_all: {}
-      },
+    filtered: {
       filter: {
         and: [
           {
@@ -93,7 +87,64 @@ test("queryNormalize", function() {
     }
   };
   deepEqual(out, exp);
-});
+
+  var in_ = emptyQuery();
+  in_.filters = [
+    {
+      type: 'range',
+      field: 'dt',
+      from: '2013-08-19T00:00:00-07:00',
+      to: '2013-08-19T08:00:00-07:00',
+      include_lower: true,
+      include_upper: false
+    }
+  ];
+  var out = backend._normalizeQuery(in_);
+  var exp = {
+    filtered: {
+      filter: {
+        and: [
+          {
+            range: {
+              dt : {
+                from: '2013-08-19T00:00:00-07:00',
+                to: '2013-08-19T08:00:00-07:00',
+                include_lower: true,
+                include_upper: false
+              }
+            }
+          }
+        ]
+      }
+    }
+  };
+  deepEqual(out, exp);
+
+  var in_ = emptyQuery();
+  in_.filters = [
+    {
+      type: 'type',
+      value: 'message'
+    }
+  ];
+  var out = backend._normalizeQuery(in_);
+  var exp = {
+    filtered: {
+      filter: {
+        and: [
+          {
+            type: {
+              value: 'message'
+            }
+          }
+        ]
+      }
+    }
+  };
+  deepEqual(out, exp);
+
+}
+);
 
 var mapping_data = {
   "note": {


### PR DESCRIPTION
add support for range and type filters:

range filter http://www.elasticsearch.org/guide/reference/query-dsl/range-filter/
example =

```
{
    type : 'range',
    field: 'dt_field',
    from: '2013-08-19T00:00:00-07:0',
    to: '2013-08-19T08:00:00-07:0',
    include_upper: true,
    include_lower: false         
}
```

type filter http://www.elasticsearch.org/guide/reference/query-dsl/range-filter/
example =

```
{
    type : 'type',
    value: 'message'     
}
```
