### PR TITLE
use POST instead of GET for _search queries to allow very long queries

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -141,10 +141,10 @@ var ES = {};
         _.each(queryInfo.filters, function(filter) {
           out.filtered.filter.and.push(self._convertFilter(filter));
         });
-        // add query string only if needed
-        if (queryInfo.q) {
-          out.filtered.query = query;
-        }
+	// add query string only if needed
+	if (queryInfo.q || queryInfo.ids) {
+	  out.filtered.query = query;
+	}
       } else {
         out = {
           constant_score: { query: {} }

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -223,8 +223,8 @@ var ES = {};
       var url = this.endpoint + '/_search';
       var jqxhr = makeRequest({
         url: url,
-        data: data,
-        dataType: this.options.dataType
+        type: 'POST',
+        data: JSON.stringify(esQuery)
       });
       return jqxhr;
     };

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -141,10 +141,10 @@ var ES = {};
         _.each(queryInfo.filters, function(filter) {
           out.filtered.filter.and.push(self._convertFilter(filter));
         });
-	// add query string only if needed
-	if (queryInfo.q || queryInfo.ids) {
-	  out.filtered.query = query;
-	}
+        // add query string only if needed
+        if (queryInfo.q) {
+          out.filtered.query = query;
+        }
       } else {
         out = {
           constant_score: { query: {} }


### PR DESCRIPTION
I changed the _search query request to do a POST instead of GET.  I needed this because I created a very long query (>8K) which was too long for the server to accept.  There is no such limit with POST.
