### PR TITLE
create an ids query if queryInfo.ids is set with a list of document ids

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -98,6 +98,12 @@ var ES = {};
             query : queryInfo.q 
           }  
         }
+      } else if (queryInfo.ids) {
+        query = {
+          ids : {
+            values : queryInfo.ids
+          }
+        }
       } else {
         query = {
           match_all: {}
@@ -118,7 +124,7 @@ var ES = {};
           out.filtered.filter.and.push(self._convertFilter(filter));
         });
 	// add query string only if needed
-	if (queryInfo.q) {
+	if (queryInfo.q || queryInfo.ids) {
 	  out.filtered.query = query;
 	}
       } else {
@@ -182,6 +188,10 @@ var ES = {};
       if (esQuery.sort && esQuery.sort.length > 0) {
         esQuery.sort = this._normalizeSort(esQuery.sort);
       }
+      if (esQuery.ids) {
+        esQuery.size = esQuery.ids.length;
+        delete esQuery.ids;
+      }        
       var data = {source: JSON.stringify(esQuery)};
       var url = this.endpoint + '/_search';
       var jqxhr = makeRequest({

--- a/test/tests.js
+++ b/test/tests.js
@@ -178,6 +178,20 @@ test("queryNormalize", function() {
   };
   deepEqual(out, exp);
 
+  // ids query 
+  var in_ = emptyQuery();
+  in_.ids = [ 1, 2, 3, 4 ];
+  var out = backend._normalizeQuery(in_);
+  var exp = {
+    constant_score: {
+      query : {
+        ids : {
+          values : [ 1, 2, 3, 4 ]
+        }
+      }
+    }
+  }
+  deepEqual(out, exp);
 }
 );
 
@@ -296,8 +310,10 @@ test("query", function() {
     equal(3, queryResult.hits.hits.length);
     equal('Note 1', queryResult.hits.hits[0]._source['title']);
   });
+
   jQuery.ajax.restore();
 });
+
 
 // DISABLED - this test requires ElasticSearch to be running locally
 // test("write", function() { 


### PR DESCRIPTION
I am using the Carrot2 plugin (https://github.com/carrot2/elasticsearch-carrot2).  It returns document clusters, each with a list of document ids.  I need to do a query with a list of document ids to get the actual documents.  To do this, I added support for an ids query.  

I set the list of ids like this:

```
this.model.queryState.set({ids: ["10869721","10833316","10849926","10913439"]});
```

which generates a query like this:

```
{
    "query": {
        "query": {
            "ids": {
                "values": [
                    "10869721", 
                    "10833316", 
                    "10849926", 
                    "10913439"
                ]
            }
        }
    }, 
    "size": 4
}
```

This list can be very long, which is why I made the earlier change to make a POST request instead of GET.
