### PR TITLE
corrected the Deferred defn. for elasticssearch.js

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -272,7 +272,7 @@ recline.Backend.ElasticSearch = recline.Backend.ElasticSearch || {};
   my.__type__ = 'elasticsearch';
 
   // use either jQuery or Underscore Deferred depending on what is available
-  var Deferred = _.isUndefined(jQuery) ? _.Deferred : jQuery.Deferred;
+  var Deferred = (typeof jQuery !== "undefined" && jQuery.Deferred) || _.Deferred;
 
   // ## Recline Connectors 
   //

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -2,7 +2,7 @@ var ES = {};
 
 (function(my) {
   // use either jQuery or Underscore Deferred depending on what is available
-  var Deferred = _.isUndefined(this.jQuery) ? _.Deferred : jQuery.Deferred;
+ var Deferred = (typeof jQuery !== "undefined" && jQuery.Deferred) || _.Deferred;
 
   // ## Table
   //


### PR DESCRIPTION
The existing definition of  `Deferred` is causing `uncaught errors` with _.isUndefined (when used in async mode with other frameworks).

Other recline backends (like csv etc.) that did not have this problem are using this  `typeof jQuery !== undefined` definition.

Correcting the code to be compatible with other backends and also eliminate the uncaught error with async exec.
